### PR TITLE
Some small things to make it compile on Ubuntu 12.04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,15 @@
 #LIBS = -L/usr/local/openssl/lib
 
 ## Where is libcl.a?
-CRYPTLIB = /usr/local/lib/libcl.a
+#CRYPTLIB = /usr/local/lib/libcl.a
 
 ## Cryptlib is usually linked with these libraries:
 EXTRA_LIBS = -lresolv -lpthread
 
+## Remember to change theese to suit your environment!!
 INCLUDES = -I/home/ams/build/cryptlib
 CRYPTLIB = /home/ams/build/cryptlib/libcl.a
 
 pemtrans: pemtrans.c
 	cc $(INCLUDES) $(LIBS) -o pemtrans pemtrans.c $(CRYPTLIB) \
-	-lssl $(EXTRA_LIBS)
+	-lcrypto -lssl $(EXTRA_LIBS)

--- a/pemtrans.c
+++ b/pemtrans.c
@@ -42,13 +42,13 @@ void check( int n, CRYPT_HANDLE c, char *s )
     if ( type != 0 )
         fprintf( stderr, "\tError type: %d\n", type );
 
-    status = cryptGetAttributeString( c, CRYPT_ATTRIBUTE_INT_ERRORMESSAGE,
+    status = cryptGetAttributeString( c, CRYPT_ATTRIBUTE_ERRORMESSAGE,
                                       0, &length );
     if ( cryptStatusOK( status ) ) {
         char * err = malloc( length );
         if ( !err )
             exit( -1 );
-        status = cryptGetAttributeString( c, CRYPT_ATTRIBUTE_INT_ERRORMESSAGE,
+        status = cryptGetAttributeString( c, CRYPT_ATTRIBUTE_ERRORMESSAGE,
                                           err, &length );
         if ( cryptStatusOK( status ) )
             fprintf( stderr, "\tError message: %s\n", err );


### PR DESCRIPTION
Changed CRYPT_ATTRIBUTE_INT_ERRORMESSAGE for CRYPT_ATTRIBUTE_ERRORMESSAGE and added -lcrypto to cc command to make Ubuntu 12.04 and anything with reasonable recent openssl work
